### PR TITLE
browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
       "distDir": "./docs"
     }
   },
+  "browserslist": [
+    "last 2 versions",
+    "not dead"
+  ],
   "scripts": {
     "prebuild": "scripts/statics.sh",
     "build": "parcel build --public-url ./",


### PR DESCRIPTION
the docs generation started failing after adding `engines` to package.json