### PR TITLE
show three icons instead of a hamburger menu

### DIFF
--- a/src/components/GameInfo.css
+++ b/src/components/GameInfo.css
@@ -1,6 +1,5 @@
 .gameInfoWrapper {
   padding: 0.25em 0 0 0;
-  position: relative;
   display: flex;
   align-items: center;
 }
@@ -22,53 +21,38 @@
   font-size: 1em;
 }
 
-.hamburger {
-  background: none;
-  border: none;
-  cursor: pointer;
+.iconButtons {
   display: flex;
-  flex-direction: column;
-  gap: 5px;
+  gap: 0.25em;
+  align-items: center;
+  font-size: 1.75em;
 }
 
-.hamburger span {
-  display: block;
-  width: 48px;
-  height: 3px;
-  background: white;
-  border-radius: 2px;
-}
-
-.menuBackdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 9;
-}
-
-.menu {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  z-index: 30;
-  background: #333;
-  border-radius: 4px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-  min-width: 150px;
-}
-
-.menu button {
-  width: 100%;
-  padding: 0.75em 1em;
+.iconButton {
   background: none;
   border: none;
-  color: white;
-  font-size: 1.1em;
-  text-align: left;
   cursor: pointer;
+  color: white;
+  padding: 0.35em;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.menu button:hover {
-  background: #444;
+.iconButton svg {
+  width: 1.75em;
+  height: 1.75em;
+  display: block;
+}
+
+.iconButton:hover {
+  color: #aaa;
+}
+
+.iconButton.destructive:hover {
+  color: red;
 }
 
 .settingsOverlay {
@@ -90,7 +74,8 @@
 }
 
 @media only screen and (max-width: 600px) and (min-width: 1px) {
-  .gameInfo {
+  .gameInfo,
+  .iconButtons {
     font-size: 1.25em;
   }
 }

--- a/src/components/GameInfo.tsx
+++ b/src/components/GameInfo.tsx
@@ -6,12 +6,20 @@ import { GameName, Multiple } from "../types";
 import { PlayerChooser } from "./PlayerChooser";
 import { SettingsSection } from "./SettingsSection";
 
+const iconProps = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
 export const GameInfo = () => {
   const game = useStore((state) => state.game);
   const winner = useStore((state) => state.winner);
   const setGame = useStore((state) => state.setGame);
   const setWinner = useStore((state) => state.setWinner);
-  const [menuOpen, setMenuOpen] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showPlayers, setShowPlayers] = useState(false);
 
@@ -19,20 +27,17 @@ export const GameInfo = () => {
     if (window.confirm("Are you sure?")) {
       setGame(null);
       setWinner(null);
-      setMenuOpen(false);
     }
   };
 
   const toggleSettings = () => {
     setShowSettings(!showSettings);
     setShowPlayers(false);
-    setMenuOpen(false);
   };
 
   const togglePlayers = () => {
     setShowPlayers(!showPlayers);
     setShowSettings(false);
-    setMenuOpen(false);
   };
 
   const oh1Game = game?.name === GameName.Oh1;
@@ -49,21 +54,44 @@ export const GameInfo = () => {
               {game.checkIn && <span>{Multiple[game.checkIn]} In</span>}
               {game.checkOut && <span>{Multiple[game.checkOut]} Out</span>}
             </div>
-            <button className="hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
-              <span />
-              <span />
-              <span />
-            </button>
-            {menuOpen && (
-              <>
-                <div className="menuBackdrop" onClick={() => setMenuOpen(false)} />
-                <div className="menu">
-                  <button onClick={togglePlayers}>Players</button>
-                  <button onClick={toggleSettings}>Settings</button>
-                  <button onClick={stopGame}>Stop Game</button>
-                </div>
-              </>
-            )}
+            <div className="iconButtons">
+              <button
+                className="iconButton"
+                onClick={togglePlayers}
+                aria-label="Players"
+                title="Players"
+              >
+                <svg {...iconProps}>
+                  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                  <circle cx="9" cy="7" r="4" />
+                  <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+                </svg>
+              </button>
+              <button
+                className="iconButton"
+                onClick={toggleSettings}
+                aria-label="Settings"
+                title="Settings"
+              >
+                <svg {...iconProps}>
+                  <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </button>
+              <button
+                className="iconButton destructive"
+                onClick={stopGame}
+                aria-label="Stop game"
+                title="Stop game"
+              >
+                <svg {...iconProps}>
+                  <path d="M2.586 16.726A2 2 0 0 1 2 15.312V8.688a2 2 0 0 1 .586-1.414l4.688-4.688A2 2 0 0 1 8.688 2h6.624a2 2 0 0 1 1.414.586l4.688 4.688A2 2 0 0 1 22 8.688v6.624a2 2 0 0 1-.586 1.414l-4.688 4.688a2 2 0 0 1-1.414.586H8.688a2 2 0 0 1-1.414-.586z" />
+                  <path d="m15 9-6 6" />
+                  <path d="m9 9 6 6" />
+                </svg>
+              </button>
+            </div>
           </div>
           {showPlayers && (
             <div className="settingsOverlay">


### PR DESCRIPTION
the other day there was some playtesting i did where I quit a game and restarted a few times in a row. the extra tap to cancel the game was driving me crazy. then I started thinking about UI affordances, and how it's just three things in that hamburger menu... what if we just showed an icon for each one? that would also make it easier to see at a glance what options are available.

feel free to 👎 and I'll close if you're strongly pro-hamburger -- or give some feedback and I'll iterate -- but I figured I'd just put up a PR as a starting point for something this small 🤷 

<img width="450" height="168" alt="Screenshot 2026-04-21 at 10 29 29 PM" src="https://github.com/user-attachments/assets/3345a2b2-1078-4e15-a2e6-fbce1ffd970a" />
